### PR TITLE
:bug: outdated node base image tag updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY src /opt/content/
 WORKDIR /opt/content/
 RUN npm install --unsafe-perm
 
-FROM node:8.11-slim
+FROM node:8-buster-slim
 MAINTAINER "Manojvv" "manojv@ilimi.in"
 RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
     && apt update \


### PR DESCRIPTION
this PR will fix the following docker build issue with outdated Debian node base image

```
#8 [stage-1 2/4] RUN sed -i '/jessie-updates/d' /etc/apt/sources.list     && apt update     && apt-get clean     && useradd -m sunbird
#8 9.344 Ign http://security.debian.org/ jessie/updates InRelease
#8 9.563 Ign http://security.debian.org/ jessie/updates Release.gpg
#8 9.567 Ign http://deb.debian.org/ jessie InRelease
#8 9.764 Ign http://security.debian.org/ jessie/updates Release
#8 9.777 Ign http://deb.debian.org/ jessie Release.gpg
#8 10.01 Ign http://deb.debian.org/ jessie Release
#8 10.15 Err http://security.debian.org/ jessie/updates/main amd64 Packages
#8 10.15   
#8 10.35 Err http://security.debian.org/ jessie/updates/main amd64 Packages
#8 10.35   
#8 10.39 Err http://deb.debian.org/ jessie/main amd64 Packages
#8 10.39   
#8 10.58 Err http://security.debian.org/ jessie/updates/main amd64 Packages
#8 10.58   
#8 10.61 Err http://deb.debian.org/ jessie/main amd64 Packages
#8 10.61   
#8 10.82 Err http://deb.debian.org/ jessie/main amd64 Packages
#8 10.82   
#8 10.93 Err http://security.debian.org/ jessie/updates/main amd64 Packages
#8 10.93   
#8 11.15 Err http://security.debian.org/ jessie/updates/main amd64 Packages
#8 11.15   404  Not Found [IP: 151.101.2.132 80]
#8 11.21 Err http://deb.debian.org/ jessie/main amd64 Packages
#8 11.21   
#8 11.44 Err http://deb.debian.org/ jessie/main amd64 Packages
#8 11.44   404  Not Found
#8 11.44 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.2.132 80]
#8 11.44 
#8 11.44 W: Failed to fetch http://deb.debian.org/debian/dists/jessie/main/binary-amd64/Packages  404  Not Found
#8 11.44 
#8 11.44 E: Some index files failed to download. They have been ignored, or old ones used instead.
#8 ERROR: process "/bin/sh -c sed -i '/jessie-updates/d' /etc/apt/sources.list     && apt update     && apt-get clean     && useradd -m sunbird" did not complete successfully: exit code: 100

#6 [stage-0 1/4] FROM docker.io/circleci/node:8.11.2-stretch@sha256:147dd7f8267b50bb827a9682bcd774c0923e03c82c2a8bbfa303bd36b7304c74
#6 extracting sha256:52c1349ba562b4e4773c511f65fd59f3e1d57c6343e4b43277828ba0516d72b9 0.1s done
#6 CANCELED
------
 > [stage-1 2/4] RUN sed -i '/jessie-updates/d' /etc/apt/sources.list     && apt update     && apt-get clean     && useradd -m sunbird:
#8 11.15   404  Not Found [IP: 151.101.2.132 80]
#8 11.21 Err http://deb.debian.org/ jessie/main amd64 Packages
#8 11.21   
#8 11.44 Err http://deb.debian.org/ jessie/main amd64 Packages
#8 11.44   404  Not Found
#8 11.44 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.2.132 80]
#8 11.44 
#8 11.44 W: Failed to fetch http://deb.debian.org/debian/dists/jessie/main/binary-amd64/Packages  404  Not Found
#8 11.44 
#8 11.44 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
Dockerfile:10
--------------------
   9 |     MAINTAINER "Manojvv" "manojv@ilimi.in"
  10 | >>> RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
  11 | >>>     && apt update \
  12 | >>>     && apt-get clean \
  13 | >>>     && useradd -m sunbird
  14 |     USER sunbird
--------------------
ERROR: failed to solve: process "/bin/sh -c sed -i '/jessie-updates/d' /etc/apt/sources.list     && apt update     && apt-get clean     && useradd -m sunbird" did not complete successfully: exit code: 100
```

@santhosh-tg